### PR TITLE
Handle empty search params values

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -24,8 +24,14 @@ pub fn parse_raw_json(input: &str) -> Option<serde_json::Value> {
 }
 
 pub fn get_parameter_value(query: &Vec<(&str, &str)>, param: &str) -> Option<String> {
-    return query
+    let param = query
         .iter()
         .find(|q| String::from(q.0) == String::from(param))
         .map(|q| q.1.to_string());
+    
+    match param {
+        Some(param) if param.is_empty() => None,
+        Some(param) if !param.is_empty() => Some(param),
+        _ => None,
+    }
 }


### PR DESCRIPTION
I found an issue when parsing query parameters in the connection URL: if a parameter contains an empty value, such as `headerType=`, it is passed to RawConfig as an empty string. It should be None